### PR TITLE
Use PERSONAL_GITHUB_TOKEN

### DIFF
--- a/build/deploy
+++ b/build/deploy
@@ -10,7 +10,7 @@ git_email=$(git log -1 --pretty=format:"%ce")
 git clone \
   --depth 1 \
   --branch ${GHPAGES_BRANCH} \
-  https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} \
+  https://${PERSONAL_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY} \
   public
 
 


### PR DESCRIPTION
Because default GITHUB_TOKEN in Actions doesn't have permissions to push